### PR TITLE
PAF-213 Remove overriding default values for rdabout18 and rdaboutcontact

### DIFF
--- a/models/ims-model.js
+++ b/models/ims-model.js
@@ -54,9 +54,6 @@ const setEformValues = (eform, caseRef) => {
   setEformValue(eform, 'dtborec', today.toLocaleDateString());
   setEformValue(eform, 'tmboec', time);
 
-  setEformValue(eform, 'rdaboutcontact', 'No');
-  setEformValue(eform, 'rdabout18', 'Yes');
-
   setEformValue(eform, 'txbofname', 'test');
   setEformValue(eform, 'txbosurname', 'test');
   setEformValue(eform, 'txbomobile', 'test');


### PR DESCRIPTION
## What? 

Removed two values (rdabout18, rdaboutcontact) from the currently set defaults provided for new cases.

## Why?

These two settings were overriding values for these fields sent from the HOF form. No matter what the user of the form entered, the values as removed would be found on the case in IMS

## Testing

After removing the two defaults observed locally that the option selected in the HOF form would appear in the IMS system case.