### PR TITLE
Update check for attachments to use msg.Attachments.length

### DIFF
--- a/models/ims-model.js
+++ b/models/ims-model.js
@@ -198,7 +198,7 @@ module.exports = {
       console.log('writeFormData ' +  eforms[i] + ' result: ' + JSON.stringify(result, null, 2));
     }
 
-    if (msg.Attachments) {
+    if (msg.Attachments.length) {
       const attachmentRefs = [];
       try {
         const fvToken = await fv.auth();


### PR DESCRIPTION
## What?

Add .length to the check on whether an SQS msg payload has attachments to upload to IMS

## Why?

This was resolving to true even for empty arrays (i.e. when there are no attachments) and although it does not attempt to upload non-existent files it does cause the code to attempt to create a note linking non-existent files to the case. This will fail and throw an error.

## How

Adding `.length` to the check asks not if there is an array at msg.Attachments (there always is so this is always true) but instead if that array has any variables (will only be true if attachments were uploaded. This update stops the conditional code block attempting to run where there are no attachments. 