### PR TITLE
Add reject param to handleMessage promise parameters

### DIFF
--- a/ims-resolver.js
+++ b/ims-resolver.js
@@ -32,7 +32,7 @@ const imsResolver = {
   },
 
   handleMessage: async message => {
-    return new Promise(async (resolve, reject) => {
+    return new Promise(async resolve => {
       const messageBody = JSON.parse(message.Body);
       // console.log(messageBody);
 

--- a/ims-resolver.js
+++ b/ims-resolver.js
@@ -32,7 +32,7 @@ const imsResolver = {
   },
 
   handleMessage: async message => {
-    return new Promise(async resolve => {
+    return new Promise(async (resolve, reject) => {
       const messageBody = JSON.parse(message.Body);
       // console.log(messageBody);
 


### PR DESCRIPTION
## What?

Add the 'reject' param to the promise arguments in the handleMessage function

## Why?

When an error was detected it still crashes because reject is not defined and it cannot send the SQS message back to the queue.