### PR TITLE
Log SQS message attributes

### DIFF
--- a/ims-resolver.js
+++ b/ims-resolver.js
@@ -34,14 +34,22 @@ const imsResolver = {
   handleMessage: async message => {
     return new Promise(async (resolve, reject) => {
       const messageBody = JSON.parse(message.Body);
+      const messageId = message.MessageId;
+      const previousReceives = message.Attributes.ApproximateReceiveCount;
+      const tzoffset = new Date().getTimezoneOffset() * 60000;
+      const messageCreatedAt = new Date(message.Attributes.SentTimestamp - tzoffset).toISOString();
+      let localISOTime = new Date(Date.now() - tzoffset).toISOString();
+
+      console.log(localISOTime, `Processing message ID: ${messageId}`);
+      console.log(localISOTime, `Message created: ${messageCreatedAt}`);
+      console.log(localISOTime, `Previous receive count: ${previousReceives}`);
       // console.log(messageBody);
 
       try {
         await createPublicAllegationsCase(messageBody);
         return resolve();
       } catch (err) {
-        const tzoffset = (new Date()).getTimezoneOffset() * 60000;
-        const localISOTime = (new Date(Date.now() - tzoffset)).toISOString();
+        localISOTime = new Date(Date.now() - tzoffset).toISOString();
         console.error(localISOTime, err.message);
         console.error(localISOTime, err.body);
         return reject(err);


### PR DESCRIPTION
## What

Log SQS message ID, message created time and receivedCount in the ims-resolver pod for each message.

## Why

This will help us cross-reference submissions in the PAF pods with messages going through the resolver into IMS. It will also help us identify messages being processed above the first try when looking for duplicates etc.